### PR TITLE
#6: Remove unused import in init.lua

### DIFF
--- a/lua/nvim-toc/init.lua
+++ b/lua/nvim-toc/init.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-local ts_utils = require "nvim-treesitter.ts_utils"
-
 M.toc_header = "Table of contents"
 
 function M.get_toc_numbered(toc)


### PR DESCRIPTION
Removed unused import of nvim-treesitter.ts_utils.

This fixes the issue of the recent breaking changes in nvim-treesitter.